### PR TITLE
Add BaseRecyclerViewAdapter for lifecycle-aware viewholder

### DIFF
--- a/app/src/main/kotlin/com/tailoredapps/template/injection/components/ActivityViewHolderComponent.kt
+++ b/app/src/main/kotlin/com/tailoredapps/template/injection/components/ActivityViewHolderComponent.kt
@@ -2,9 +2,10 @@ package com.tailoredapps.template.injection.components
 
 import com.tailoredapps.template.injection.modules.ViewHolderModule
 import com.tailoredapps.template.injection.modules.ViewModelModule
+import com.tailoredapps.template.injection.qualifier.ViewHolderDisposable
 import com.tailoredapps.template.injection.scopes.PerViewHolder
-
 import dagger.Component
+import io.reactivex.disposables.CompositeDisposable
 
 /* Copyright 2017 Tailored Media GmbH
  *
@@ -21,6 +22,13 @@ import dagger.Component
  * limitations under the License. */
 @PerViewHolder
 @Component(dependencies = [(ActivityComponent::class)], modules = [(ViewHolderModule::class), (ViewModelModule::class)])
-interface ActivityViewHolderComponent {
+interface ActivityViewHolderComponent : ActivityViewHolderComponentProvides {
+    // create inject methods for your Activity ViewHolder here
+
+}
+
+interface ActivityViewHolderComponentProvides {
+
+    @ViewHolderDisposable fun viewHolderDisposable(): CompositeDisposable
 
 }

--- a/app/src/main/kotlin/com/tailoredapps/template/injection/components/FragmentViewHolderComponent.kt
+++ b/app/src/main/kotlin/com/tailoredapps/template/injection/components/FragmentViewHolderComponent.kt
@@ -2,8 +2,10 @@ package com.tailoredapps.template.injection.components
 
 import com.tailoredapps.template.injection.modules.ViewHolderModule
 import com.tailoredapps.template.injection.modules.ViewModelModule
+import com.tailoredapps.template.injection.qualifier.ViewHolderDisposable
 import com.tailoredapps.template.injection.scopes.PerViewHolder
 import dagger.Component
+import io.reactivex.disposables.CompositeDisposable
 
 /* Copyright 2017 Tailored Media GmbH
  *
@@ -21,5 +23,12 @@ import dagger.Component
 @PerViewHolder
 @Component(dependencies = [(FragmentComponent::class)], modules = [(ViewHolderModule::class), (ViewModelModule::class)])
 interface FragmentViewHolderComponent {
+    // create inject methods for your Fragment ViewHolder here
+
+}
+
+interface FragmentViewHolderComponentProvides {
+
+    @ViewHolderDisposable fun viewHolderDisposable(): CompositeDisposable
 
 }

--- a/app/src/main/kotlin/com/tailoredapps/template/injection/qualifier/ViewHolderDisposable.kt
+++ b/app/src/main/kotlin/com/tailoredapps/template/injection/qualifier/ViewHolderDisposable.kt
@@ -1,12 +1,4 @@
-package com.tailoredapps.template.injection.modules
-
-import com.tailoredapps.template.injection.qualifier.ViewHolderDisposable
-import com.tailoredapps.template.injection.scopes.PerViewHolder
-import dagger.Module
-import dagger.Provides
-import io.reactivex.disposables.CompositeDisposable
-
-/* Copyright 2016 Patrick Löwenstein
+/* Copyright 2017 Tailored Media GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,12 +11,12 @@ import io.reactivex.disposables.CompositeDisposable
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License. */
-@Module
-class ViewHolderModule {
 
-    @Provides
-    @PerViewHolder
-    @ViewHolderDisposable
-    internal fun provideCompositeDisposable(): CompositeDisposable = CompositeDisposable()
+package com.tailoredapps.template.injection.qualifier
 
-}
+import javax.inject.Qualifier
+
+
+@Qualifier
+@Retention(AnnotationRetention.RUNTIME)
+annotation class ViewHolderDisposable

--- a/app/src/main/kotlin/com/tailoredapps/template/ui/base/BaseActivityViewHolder.kt
+++ b/app/src/main/kotlin/com/tailoredapps/template/ui/base/BaseActivityViewHolder.kt
@@ -7,10 +7,13 @@ import android.view.View
 import com.tailoredapps.template.BR
 import com.tailoredapps.template.injection.components.ActivityViewHolderComponent
 import com.tailoredapps.template.injection.components.DaggerActivityViewHolderComponent
+import com.tailoredapps.template.injection.qualifier.ViewHolderDisposable
 import com.tailoredapps.template.ui.base.view.MvvmView
+import com.tailoredapps.template.ui.base.view.MvvmViewHolder
 import com.tailoredapps.template.ui.base.viewmodel.MvvmViewModel
 import com.tailoredapps.template.util.extensions.attachViewOrThrowRuntimeException
 import com.tailoredapps.template.util.extensions.castWithUnwrap
+import io.reactivex.disposables.CompositeDisposable
 import javax.inject.Inject
 
 /* Copyright 2016 Patrick Löwenstein
@@ -35,20 +38,24 @@ import javax.inject.Inject
 /* Base class for ViewHolders when using a view model in an Activity with data binding.
  * This class provides the binding and the view model to the subclass. The
  * view model is injected and the binding is created when the content view is bound.
- * Each subclass therefore has to call the following code in the constructor:
- *    bindContentView(view)
+ * The binding and the view model are initialized in the initialisation of the class.
  *
- * After calling this method, the binding and the view model is initialized.
  * saveInstanceState() and restoreInstanceState() are not called/used for ViewHolder
  * view models.
  *
+ * Note, that the `BaseRecyclerViewAdapter` needs to be used if the attachView and detachView
+ * methods should be invoked respectively.
+ *
  * Your subclass must implement the MvvmView implementation that you use in your
  * view model. */
-abstract class BaseActivityViewHolder<B : ViewDataBinding, VM : MvvmViewModel<*>>(itemView: View) : RecyclerView.ViewHolder(itemView), MvvmView {
+abstract class BaseActivityViewHolder<B : ViewDataBinding, VM : MvvmViewModel<*>>(itemView: View) : RecyclerView.ViewHolder(itemView), MvvmView, MvvmViewHolder {
 
-    protected lateinit var binding: B
+    protected val binding: B
     @Inject lateinit var viewModel: VM
         protected set
+
+    @field:[Inject ViewHolderDisposable]
+    internal lateinit var disposable: CompositeDisposable
 
     protected val viewHolderComponent: ActivityViewHolderComponent by lazy {
         DaggerActivityViewHolderComponent.builder()
@@ -56,16 +63,24 @@ abstract class BaseActivityViewHolder<B : ViewDataBinding, VM : MvvmViewModel<*>
                 .build()
     }
 
-    protected fun bindContentView(view: View) {
+    init {
         try {
             ActivityViewHolderComponent::class.java.getDeclaredMethod("inject", this::class.java).invoke(viewHolderComponent, this)
-        } catch(e: NoSuchMethodException) {
+        } catch (e: NoSuchMethodException) {
             throw RtfmException("You forgot to add \"fun inject(viewHolder: ${this::class.java.simpleName})\" in ActivityViewHolderComponent")
         }
 
-        binding = DataBindingUtil.bind(view)!!
+        binding = DataBindingUtil.bind(itemView)!!
         binding.setVariable(BR.vm, viewModel)
+    }
+
+    override fun onBindViewHolder() {
         viewModel.attachViewOrThrowRuntimeException(this, null)
+    }
+
+    override fun onViewHolderRecycled() {
+        disposable.clear()
+        viewModel.detachView()
     }
 
     fun executePendingBindings() {

--- a/app/src/main/kotlin/com/tailoredapps/template/ui/base/BaseFragmentViewHolder.kt
+++ b/app/src/main/kotlin/com/tailoredapps/template/ui/base/BaseFragmentViewHolder.kt
@@ -10,54 +10,70 @@ import android.view.View
 import com.tailoredapps.template.BR
 import com.tailoredapps.template.injection.components.DaggerFragmentViewHolderComponent
 import com.tailoredapps.template.injection.components.FragmentViewHolderComponent
+import com.tailoredapps.template.injection.qualifier.ViewHolderDisposable
 import com.tailoredapps.template.ui.base.view.MvvmView
+import com.tailoredapps.template.ui.base.view.MvvmViewHolder
 import com.tailoredapps.template.ui.base.viewmodel.MvvmViewModel
 import com.tailoredapps.template.util.extensions.attachViewOrThrowRuntimeException
 import com.tailoredapps.template.util.extensions.castWithUnwrap
+import io.reactivex.disposables.CompositeDisposable
 import javax.inject.Inject
 
 /* Base class for ViewHolders when using a view model in a Fragment with data binding.
  * This class provides the binding and the view model to the subclass. The
  * view model is injected and the binding is created when the content view is bound.
- * Each subclass therefore has to call the following code in the constructor:
- *    bindContentView(view)
+ * The binding and the view model are initialized in the initialisation of the class.
  *
- * After calling this method, the binding and the view model is initialized.
  * saveInstanceState() and restoreInstanceState() are not called/used for ViewHolder
  * view models.
  *
+ * Note, that the `BaseRecyclerViewAdapter` needs to be used if the attachView and detachView
+ * methods should be invoked respectively.
+ *
  * Your subclass must implement the MvvmView implementation that you use in your
  * view model. */
-abstract class BaseFragmentViewHolder<B : ViewDataBinding, VM : MvvmViewModel<*>>(itemView: View) : RecyclerView.ViewHolder(itemView), MvvmView {
+abstract class BaseFragmentViewHolder<B : ViewDataBinding, VM : MvvmViewModel<*>>(itemView: View) : RecyclerView.ViewHolder(itemView), MvvmView, MvvmViewHolder {
 
-    protected lateinit var binding: B
+    protected val binding: B
     @Inject lateinit var viewModel: VM
         protected set
 
-    protected abstract val fragmentContainerId : Int
+    protected abstract val fragmentContainerId: Int
+
+    @field:[Inject ViewHolderDisposable]
+    internal lateinit var disposable: CompositeDisposable
 
     protected val viewHolderComponent: FragmentViewHolderComponent by lazy {
         DaggerFragmentViewHolderComponent.builder()
-                .fragmentComponent(itemView.context.getFragment<BaseFragment<*,*>>(fragmentContainerId)!!.fragmentComponent)
+                .fragmentComponent(itemView.context.getFragment<BaseFragment<*, *>>(fragmentContainerId)!!.fragmentComponent)
                 .build()
     }
 
-    protected fun bindContentView(view: View) {
+    init {
         try {
             FragmentViewHolderComponent::class.java.getDeclaredMethod("inject", this::class.java).invoke(viewHolderComponent, this)
-        } catch(e: NoSuchMethodException) {
+        } catch (e: NoSuchMethodException) {
             throw RtfmException("You forgot to add \"fun inject(viewHolder: ${this::class.java.simpleName})\" in FragmentViewHolderComponent")
         }
 
-        binding = DataBindingUtil.bind(view)!!
+        binding = DataBindingUtil.bind(itemView)!!
         binding.setVariable(BR.vm, viewModel)
+    }
+
+    override fun onBindViewHolder() {
         viewModel.attachViewOrThrowRuntimeException(this, null)
+    }
+
+    override fun onViewHolderRecycled() {
+        disposable.clear()
+        viewModel.detachView()
+    }
+
+    fun executePendingBindings() {
+        binding.executePendingBindings()
     }
 
     private inline fun <reified T : Fragment> Context.getFragment(containerId: Int) =
             castWithUnwrap<FragmentActivity>()?.run { supportFragmentManager.findFragmentById(containerId) as? T }
 
-    fun executePendingBindings() {
-        binding.executePendingBindings()
-    }
 }

--- a/app/src/main/kotlin/com/tailoredapps/template/ui/base/BaseRecyclerViewAdapter.kt
+++ b/app/src/main/kotlin/com/tailoredapps/template/ui/base/BaseRecyclerViewAdapter.kt
@@ -1,0 +1,26 @@
+package com.tailoredapps.template.ui.base
+
+import android.support.annotation.CallSuper
+import android.support.v7.widget.RecyclerView
+import com.tailoredapps.template.ui.base.view.MvvmViewHolder
+
+
+/**
+ * Base class for [RecyclerView.Adapter] when caring about the view holder's lifecycle.
+ *
+ * Using this base adapter, the view models `attachView` and `detachView` methods will be invoked,
+ * as well as the `ViewHolderDisposable` will be cleared.
+ */
+abstract class BaseRecyclerViewAdapter<VH : RecyclerView.ViewHolder> : RecyclerView.Adapter<VH>() {
+
+    @CallSuper
+    override fun onBindViewHolder(holder: VH, position: Int) {
+        (holder as? MvvmViewHolder)?.onBindViewHolder()
+    }
+
+    override fun onViewRecycled(holder: VH) {
+        super.onViewRecycled(holder)
+        (holder as? MvvmViewHolder)?.onViewHolderRecycled()
+    }
+
+}

--- a/app/src/main/kotlin/com/tailoredapps/template/ui/base/view/MvvmViewHolder.kt
+++ b/app/src/main/kotlin/com/tailoredapps/template/ui/base/view/MvvmViewHolder.kt
@@ -1,0 +1,6 @@
+package com.tailoredapps.template.ui.base.view
+
+interface MvvmViewHolder {
+    fun onBindViewHolder()
+    fun onViewHolderRecycled()
+}


### PR DESCRIPTION
This PR adds a base class for `RecyclerView-Adapter`, which enables ViewHoldes to be lifecycle aware by calling attachView/detachView respectively.